### PR TITLE
Initial release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Kyle Robinson Young
+Copyright (c) 2016 Walmart Labs
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -1,14 +1,73 @@
-# stylus-loader
-A [stylus](http://learnboost.github.io/stylus/) loader for [webpack](https://github.com/webpack/webpack).
+# stylus-relative-loader
+A [stylus](http://learnboost.github.io/stylus/) loader for [webpack](https://github.com/webpack/webpack),
+with fixed relative imports.
 
-[![build status](https://secure.travis-ci.org/shama/stylus-loader.svg)](https://travis-ci.org/shama/stylus-loader)
-[![NPM version](https://badge.fury.io/js/stylus-loader.svg)](https://badge.fury.io/js/stylus-loader)
+[![NPM version](https://badge.fury.io/js/stylus-relative-loader.svg)](https://badge.fury.io/js/stylus-relative-loader)
+
+## vs. stylus-loader
+
+With `stylus-loader` (which inherits a lot of behavior from Stylus itself),
+relative path imports like `./variables` and `./color`, don't necessarily
+resolve to the path relative to the file in which the import is found. In fact,
+they have the same meaning as just importing `variables` and `color`. This means
+the paths are resolved using the Stylus "context" – in effect, you could get the
+file at the requested relative path, a file in an ancestor directory, a node
+module, or a file within another module that happens to have the same name.
+
+For example:
+
+```
+styles
+├── a
+│   ├── color.styl
+│   └── index.styl
+├── b
+│   ├── color.styl
+│   └── index.styl
+├── color.styl
+└── index.styl
+```
+
+Let's say `styles/index.styl` contains:
+
+```stylus
+@import './a';
+@import './b';
+@import './color';
+```
+
+...while `a/index.styl` and `b/index.styl` both contain:
+
+```stylus
+@import './color';
+```
+
+With vanilla `stylus-loader`, the output would be ONLY the contents of
+`styles/color.styl`, repeat 3 times. Despite the `./color` imports in `a` and
+`b` explicitly calling for `a/color.styl` and `b/color.styl` to be included,
+they won't be – merely by virtue of trying to import a relative path of the
+same name.
+
+If you're using very modularized styles (say, some of your imports come from
+`node_modules`) this behavior can spell big trouble. You basically have to
+ensure that all Stylus filenames in your dependency tree are unique, otherwise
+some styles/variables/mixins might go missing!
+
+`stylus-relative-loader` fixes this issue by patching relative imports to all
+resolve as if they were full absolute paths. That means you'd get all of
+`color.styl`, `a/color.styl`, and `b/color.styl` above.
+
+### Status of this fork
+
+There are no doubt people depending on the behavior described above, using it as
+a feature, not a bug. We'd love it if this behavior were adopted upstream, as
+we don't intend to fully support this fork for a wide audience in the long-term.
 
 ## Usage
 
 ```js
-var css = require('!raw!stylus!./file.styl'); // Just the CSS
-var css = require('!css!stylus!./file.styl'); // CSS with processed url(...)s
+var css = require('!raw!stylus-relative!./file.styl'); // Just the CSS
+var css = require('!css!stylus-relative!./file.styl'); // CSS with processed url(...)s
 ```
 
 See [css-loader](https://github.com/webpack/css-loader) to see the effect of processed `url(...)`s.
@@ -19,7 +78,7 @@ Or within the webpack config:
 module: {
   loaders: [{
     test: /\.styl$/,
-    loader: 'css-loader!stylus-loader?paths=node_modules/bootstrap-stylus/stylus/'
+    loader: 'css-loader!stylus-relative-loader?paths=node_modules/bootstrap-stylus/stylus/'
   }]
 }
 ```
@@ -31,14 +90,14 @@ Use in tandem with the [style-loader](https://github.com/webpack/style-loader) t
 ```js
 module: {
   loaders: [
-    { test: /\.styl$/, loader: 'style-loader!css-loader!stylus-loader' }
+    { test: /\.styl$/, loader: 'style-loader!css-loader!stylus-relative-loader' }
   ]
 }
 ```
 
 and then `require('./file.styl');` will compile and add the CSS to your page.
 
-`stylus-loader` can also take advantage of webpack's resolve options. With the default options it'll find files in `web_modules` as well as `node_modules`, make sure to prefix any lookup in node_modules with `~`. For example if you have a styles package lookup files in it like `@import '~styles/my-styles`. It can also find stylus files without having the extension specified in the `@import` and index files in folders if webpack is configured for stylus's file extension.
+`stylus-relative-loader` can also take advantage of webpack's resolve options. With the default options it'll find files in `web_modules` as well as `node_modules`, make sure to prefix any lookup in node_modules with `~`. For example if you have a styles package lookup files in it like `@import '~styles/my-styles`. It can also find stylus files without having the extension specified in the `@import` and index files in folders if webpack is configured for stylus's file extension.
 
 ```js
 module: {
@@ -60,7 +119,7 @@ You can also use stylus plugins by adding an extra `stylus` section to your `web
 var stylus_plugin = require('stylus_plugin');
 module: {
   loaders: [
-    { test: /\.styl$/, loader: 'style-loader!css-loader!stylus-loader' }
+    { test: /\.styl$/, loader: 'style-loader!css-loader!stylus-relative-loader' }
   ]
 },
 stylus: {
@@ -83,11 +142,11 @@ where `~` resolves to `node_modules/`
 
 ## Install
 
-`npm install stylus-loader stylus --save-dev`
+`npm install stylus-relative-loader stylus --save-dev`
 
 **Important**: in order to have ability use any `stylus` package version,
 it won't be installed automatically. So it's required to
-add it to `package.json` along with `stylus-loader`.
+add it to `package.json` along with `stylus-relative-loader`.
 
 ## Testing
 
@@ -101,24 +160,4 @@ open http://localhost:8080/test/
 In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
-* Please see https://github.com/shama/stylus-loader/releases
-* 2.1.0 - Add support for stylus's include and set (@michaek)
-* 2.0.1 - Add peer dependency on stylus (@jchitel), fix PathCache for webpack 2 (@Unhelpful)
-* 2.0.0 - Remove dependency on stylus (@kossnocorps)
-* 1.6.1 - Remove version breaking change in 1.6.0
-* 1.6.0 - Remove dependency on stylus (@kossnocorps)
-* 1.3.0 - resolve use() calls (@mzgoddard), manual imports through path cache (@mzgoddard)
-* 1.2.0 - files in package.json (@SimenB), test running with testem (@mzgoddard), and some performance changes (@mzgoddard)
-* 1.1.0 - Pass through sourceMap option to stylus instead of defaulting to inline. Inherit source-map from devtool (@jordansexton).
-* 1.0.0 - Basic source map support (@skozin). Remove nib as dep. stylus is now a direct dep (as peerDependencies are deprecated).
-* 0.6.0 - Support loader prefixes when resolving paths (@kpdecker).
-* 0.5.0 - Disable Stylus parser caching in listImports (@DaQuirm). Update to stylus@0.49.2 and nib@1.0.4 as peerDependencies (@kompot).
-* 0.4.0 - Allow configuration of plugins through webpack config (@bobzoller). Update to stylus 0.47.2 (@shanewilson).
-* 0.3.1 - Fix when dependency (@tkellen)
-* 0.3.0 - Define url resolver() when "resolve url" option is true (@mzgoddard).
-* 0.2.0 - Now tracks dependencies for @import statements making cacheable work. Update stylus dep.
-* 0.1.0 - Initial release
-
-## License
-Copyright (c) 2014 Kyle Robinson Young  
-Licensed under the MIT license.
+* 2.1.0 - Initial release tracking `stylus-loader@2.1.0`, with fixed relative imports.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Let's say `styles/index.styl` contains:
 ```
 
 With vanilla `stylus-loader`, the output would be ONLY the contents of
-`styles/color.styl`, repeat 3 times. Despite the `./color` imports in `a` and
+`styles/color.styl`, repeated 3 times. Despite the `./color` imports in `a` and
 `b` explicitly calling for `a/color.styl` and `b/color.styl` to be included,
 they won't be – merely by virtue of trying to import a relative path of the
 same name.

--- a/README.md
+++ b/README.md
@@ -161,3 +161,4 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 * 2.1.0 - Initial release tracking `stylus-loader@2.1.0`, with fixed relative imports.
+* Find pre-fork releases of `stylus-loader` at https://github.com/shama/stylus-loader/releases

--- a/lib/listimports.js
+++ b/lib/listimports.js
@@ -1,3 +1,4 @@
+var Path = require('path');
 var Parser = require('stylus/lib/parser');
 var Visitor = require('stylus/lib/visitor');
 var nodes = require('stylus/lib/nodes');
@@ -63,6 +64,11 @@ function listImports(source, options) {
   }
   var importVisitor = new ImportVisitor(ast, {});
   importVisitor.visit(ast);
+
+  var context = options.context;
+  importVisitor.importPaths = importVisitor.importPaths.map(function(path) {
+    return path && path.indexOf('.') === 0 ? Path.join(context, path) : path;
+  });
 
   if (cache) {
     cache[source] = importVisitor.importPaths;

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -203,7 +203,10 @@ function resolveFileDeep(helpers, parentCache, source, fullPath) {
     // List imports and use its cache. The source file is translated into a
     // list of imports. Where the source file came from isn't important for the
     // list. The where is added by resolveMany with the context and resolvers.
-    .then(partialRight(listImports, { cache: parentCache.imports }))
+    .then(partialRight(listImports, {
+      cache: parentCache.imports,
+      context: context
+    }))
     .then(resolveMany.bind(null, resolvers, context))
     .then(function(newPaths) {
       // Contexts are the full path since multiple could be in the same folder

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "stylus-loader",
+  "name": "stylus-relative-loader",
   "version": "2.1.0",
-  "description": "Stylus loader for webpack",
+  "description": "Stylus loader for webpack, with fixed relative imports",
   "main": "index.js",
   "files": [
     "index.js",
@@ -13,14 +13,14 @@
     "test-one": "testem ci -l firefox",
     "test-build": "webpack --config test/webpack.config.js --output-path test/tmp --output-file bundle.js"
   },
-  "author": "Kyle Robinson Young <kyle@dontkry.com> (http://dontkry.com)",
+  "author": "Brian Beck <brian.beck@formidable.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:shama/stylus-loader.git"
+    "url": "git@github.com:walmartlabs/stylus-relative-loader.git"
   },
   "bugs": {
-    "url": "https://github.com/shama/stylus-loader/issues"
+    "url": "https://github.com/walmartlabs/stylus-relative-loader/issues"
   },
   "dependencies": {
     "loader-utils": "^0.2.9",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -165,4 +165,11 @@ describe("basic", function() {
     css.should.match(/\.a-color/);
     css.should.match(/\.b-color/);
   });
+	it("imports the right file based on relative path", function() {
+		var css = require("!raw-loader!..!./fixtures/relative");
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.a-color/);
+		css.should.match(/\.b-color/);
+		css.should.match(/\.c-color/);
+	});
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -159,12 +159,12 @@ describe("basic", function() {
 		css.should.match(/\.other/);
 		css.should.match(/a\.button/);
 	});
-  it("imports the right file based on context", function() {
-    var css = require("!raw-loader!..!./fixtures/context");
-    (typeof css).should.be.eql("string");
-    css.should.match(/\.a-color/);
-    css.should.match(/\.b-color/);
-  });
+	it("imports the right file based on context", function() {
+		var css = require("!raw-loader!..!./fixtures/context");
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.a-color/);
+		css.should.match(/\.b-color/);
+	});
 	it("imports the right file based on relative path", function() {
 		var css = require("!raw-loader!..!./fixtures/relative");
 		(typeof css).should.be.eql("string");

--- a/test/fixtures/relative/a/color.styl
+++ b/test/fixtures/relative/a/color.styl
@@ -1,0 +1,3 @@
+.a-color {
+  color: #aaa;
+}

--- a/test/fixtures/relative/a/index.styl
+++ b/test/fixtures/relative/a/index.styl
@@ -1,0 +1,1 @@
+@import './color';

--- a/test/fixtures/relative/b/color.styl
+++ b/test/fixtures/relative/b/color.styl
@@ -1,0 +1,3 @@
+.b-color {
+  color: #bbb;
+}

--- a/test/fixtures/relative/b/index.styl
+++ b/test/fixtures/relative/b/index.styl
@@ -1,0 +1,1 @@
+@import './color';

--- a/test/fixtures/relative/color.styl
+++ b/test/fixtures/relative/color.styl
@@ -1,0 +1,3 @@
+.c-color {
+  color: #ccc;
+}

--- a/test/fixtures/relative/index.styl
+++ b/test/fixtures/relative/index.styl
@@ -1,0 +1,3 @@
+@import './a';
+@import './b';
+@import './color';


### PR DESCRIPTION
Adds sane relative import behavior and test case. Updates docs to refer to `stylus-relative-loader`, and describes the purpose of our fork.

It strikes me now that another strategy could be taking `stylus-loader` as a dependency and attempting to monkeypatch `listimports`, instead of forking... I don't feel strongly either way.

/cc @ryan-roemer @ryanisinallofus 
