### PR TITLE
Lower build times by resolving as many imports as we know about before each render() retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: node_js
 node_js:
+  - "6.2.2"
+  - "5.12.0"
+  - "4.4.7"
   - "iojs"
   - "0.12"
-  - "0.10"
 sudo: false
 env:
   matrix:
     - WEBPACK_VERSION=1.13.1 WEBPACK_DEV_SERVER_VERSION=1.7.0
-    - WEBPACK_VERSION=2.1.0-beta.7 WEBPACK_DEV_SERVER_VERSION=2.1.0-beta.0
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -1,4 +1,5 @@
 'use strict';
+var dirname = require('path').dirname;
 var Evaluator = require('stylus/lib/visitor/evaluator');
 var utils = require('stylus/lib/utils');
 var loaderUtils = require('loader-utils');
@@ -8,7 +9,7 @@ var _find = utils.find;
 function find(options, path, paths, filename) {
   var found = _find.call(utils, path, paths, filename);
   if (found) {
-    options.addDependencies(found);
+    options.importCache.addDependencies(found);
   }
   return found;
 }
@@ -26,8 +27,7 @@ function lookupIndex(options, name, paths, filename) {
   if (!found) {
     var context = paths[paths.length - 1];
     var request = loaderUtils.urlToRequest(name, options.root);
-    var contextImports = options.resolvedImports[context] || {};
-    var result = contextImports[request];
+    var result = options.importCache.lookupImport(context, request);
     if (result) {
       found = [result];
     } else {
@@ -35,27 +35,61 @@ function lookupIndex(options, name, paths, filename) {
     }
   }
   if (found) {
-    options.addDependencies(found);
+    options.importCache.addDependencies(found);
   }
   return found;
 }
 
-function CachedPathEvaluator(root, options) {
-  Evaluator.apply(this, arguments);
-
-  this.loaderOptions = options;
+function CachedPathEvaluator() {
+  return Evaluator.apply(this, arguments);
 }
 
 CachedPathEvaluator.prototype = Object.create(Evaluator.prototype);
 CachedPathEvaluator.prototype.constructor = CachedPathEvaluator;
 
-var _visitImport = CachedPathEvaluator.prototype.visitImport;
+/**
+ * Given an array of `nodes`, find any Import nodes that have a static webpack
+ * path - that is, begins with `~` and is not an expression with things like
+ * variable interpolation, etc. Add them to the import queue to be resolved
+ * the next time we escape the render in progress.
+ * @param {Array} nodes - An array of Stylus AST nodes.
+ * @return {undefined}
+ */
+CachedPathEvaluator.prototype._enqueueImportNodes = function(nodes) {
+  nodes.forEach(function(node) {
+    if (node.constructor.name === 'Import' &&
+        node.path.nodes.length === 1 &&
+        node.path.first.constructor.name === 'String') {
+      var pathNode = node.path.first;
+      if (pathNode.val.indexOf('~') === 0) {
+        var context = dirname(pathNode.filename);
+        var request = loaderUtils.urlToRequest(pathNode.val, this.options.root);
+        this.options.importCache.enqueueImport(context, request);
+      }
+    }
+  }, this);
+};
+
+CachedPathEvaluator.prototype.visitRoot = function(block) {
+  /* eslint-disable eqeqeq */
+  // This is how Stylus itself checks (==), so duplicate that here.
+  if (block == this.root) {
+    this._enqueueImportNodes(block.nodes);
+  }
+  return Evaluator.prototype.visitRoot.apply(this, arguments);
+};
+
+CachedPathEvaluator.prototype.visitBlock = function(block) {
+  this._enqueueImportNodes(block.nodes);
+  return Evaluator.prototype.visitBlock.apply(this, arguments);
+};
+
 CachedPathEvaluator.prototype.visitImport = function() {
   // Patch up `utils.find` and `utils.lookupIndex` with our custom hook.
-  utils.find = find.bind(utils, this.loaderOptions);
-  utils.lookupIndex = lookupIndex.bind(utils, this.loaderOptions);
+  utils.find = find.bind(utils, this.options);
+  utils.lookupIndex = lookupIndex.bind(utils, this.options);
   try {
-    return _visitImport.apply(this, arguments);
+    return Evaluator.prototype.visitImport.apply(this, arguments);
   } finally {
     // Replace originals in case other libraries are doing stuff with `stylus`.
     utils.find = _find;

--- a/lib/import-cache.js
+++ b/lib/import-cache.js
@@ -1,0 +1,140 @@
+'use strict';
+var path = require('path');
+var whenNodefn = require('when/node/function');
+var UnresolvedImport = require('./unresolved-import');
+
+function ImportCache(loaderContext) {
+  // webpack's `resolve`, promisified.
+  this.resolve = whenNodefn.lift(loaderContext.resolve).bind(loaderContext);
+  this.resolveCache = {};
+  this.resolveQueue = [];
+  this.dependencies = {};
+}
+
+ImportCache.prototype.lookupImport = function(context, request) {
+  var contextImports = this.resolveCache[context] || {};
+  return contextImports[request];
+};
+
+ImportCache.prototype.cacheImport = function(context, request, result) {
+  var contextImports = this.resolveCache[context] || {};
+  contextImports[request] = result;
+  this.resolveCache[context] = contextImports;
+};
+
+/**
+ * Use webpack's `resolve` to resolve the given Stylus import, which may
+ * require multiple attempts.
+ * @param {String} context - Directory of the file in which the import is found.
+ * @param {String} request - Path the file is attempting to import.
+ * @return {Promise} Promise that will evaluate to the resolved import path,
+ *                   or throw if it can't be resolved.
+ */
+ImportCache.prototype.resolveStylusImport = function(context, request) {
+  var cached = this.lookupImport(context, request);
+  if (cached) {
+    return Promise.resolve(cached);
+  }
+
+  var finalRequest = request;
+  var indexRequest;
+
+  // Check if it's a CSS import.
+  var literal = /\.css(?:"|$)/.test(request);
+
+  // If it's not CSS and it doesn't end in .styl, try adding '.styl'
+  // and '/index.styl'
+  if (!literal && !/\.styl$/i.test(request)) {
+    finalRequest += '.styl';
+    indexRequest = path.join(request, 'index.styl');
+  }
+
+  var self = this;
+  var resolveRequest = this.resolve(context, finalRequest);
+
+  if (indexRequest) {
+    resolveRequest = resolveRequest.catch(function() {
+      finalRequest = indexRequest;
+      return self.resolve(context, finalRequest);
+    });
+  }
+
+  return resolveRequest.then(function(result) {
+    self.cacheImport(context, request, result);
+    self.cacheImport(context, finalRequest, result);
+    return result;
+  });
+};
+
+ImportCache.prototype.enqueueImport = function(context, request) {
+  // Make sure it's not already resolved.
+  if (!this.lookupImport(context, request)) {
+    // Check that it doesn't already exist in the queue, to prevent duplicates.
+    // This isn't really necessary, and looping on every `push` isn't super
+    // efficient, but we don't expect the queue to grow very large, and it's
+    // cleaner if there are no duplicates.
+    var existing = this.resolveQueue.filter(function(unresolvedImport) {
+      return unresolvedImport[0] === context && unresolvedImport[1] === request;
+    });
+    if (!existing.length) {
+      this.resolveQueue.push([context, request]);
+    }
+  }
+};
+
+ImportCache.prototype.flushImportQueue = function() {
+  if (this.resolveQueue.length) {
+    var self = this;
+    var next = this.resolveQueue.shift();
+    var context = next[0];
+    var request = next[1];
+    // We could use `Promise.all` and process the whole queue with as much
+    // parallelism as webpack's `resolve` will allow, but that must not be much
+    // because it didn't end up saving any time when tested.
+    return this.resolveStylusImport(context, request).then(function() {
+      return self.flushImportQueue();
+    });
+  } else {
+    return Promise.resolve();
+  }
+};
+
+ImportCache.prototype.addDependencies = function(filenames) {
+  // We could just call `addDependency` from `loaderContext` here each time we
+  // encounter some dependencies, but there will be lots of duplicates, and
+  // we don't want to trust that webpack's implementation of `addDependency` is
+  // efficient. So collect all dependencies until the end, then add them in one
+  // batch.
+  filenames.forEach(function(filename) {
+    this.dependencies[filename] = true;
+  }, this);
+};
+
+ImportCache.prototype.getDependencies = function() {
+  return Object.keys(this.dependencies);
+};
+
+/**
+ * Return a function suitable for passing to a Promise's `catch`, that
+ * catches any `UnresolvedImport` errors and attempts to resolve them (along
+ * with any other queued imports) before trying again via `done`.
+ * @param {Function} done - A retry function that returns the final value or
+ *                          a Promise.
+ * @return {Function} A function for use with a Promise's `catch`.
+ */
+ImportCache.prototype.createUnresolvedImportHandler = function(done) {
+  var self = this;
+  return function(err) {
+    if (!(err instanceof UnresolvedImport)) {
+      throw err;
+    }
+
+    var context = err.importContext;
+    var request = err.importRequest;
+
+    self.enqueueImport(context, request);
+    return self.flushImportQueue().then(done);
+  };
+};
+
+module.exports = ImportCache;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lib/"
   ],
   "scripts": {
+    "check": "npm run lint && npm test",
     "lint": "eslint *.js lib",
     "test": "testem ci",
     "test-dev": "testem -l firefox",
@@ -40,13 +41,13 @@
     "raw-loader": "~0.5.1",
     "should": "~4.6.1",
     "style-loader": "^0.12.2",
-    "stylus": ">=0.52.4",
+    "stylus": "^0.54.5",
     "testem": "^0.8.3",
     "webpack": "^1.9.8",
     "webpack-dev-server": "~1.7.0"
   },
   "peerDependencies": {
-    "stylus": ">=0.52.4"
+    "stylus": "^0.54.5"
   },
   "keywords": [
     "webpack",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "nib": "^1.0.4",
     "node-libs-browser": "^0.5.2",
     "raw-loader": "~0.5.1",
-    "should": "~4.6.1",
+    "should": "^9.0.2",
     "style-loader": "^0.12.2",
     "stylus": "^0.54.5",
     "testem": "^0.8.3",

--- a/test/all.js
+++ b/test/all.js
@@ -1,1 +1,2 @@
 require("./basic.test.js");
+require("./import-cache.test.js");

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -172,4 +172,10 @@ describe("basic", function() {
     css.should.match(/\.b-color/);
     css.should.match(/\.c-color/);
   });
+  it("supports dynamic import paths", function() {
+    var css = require("!raw-loader!..!./fixtures/dynamic");
+    (typeof css).should.be.eql("string");
+    css.should.not.match(/\.a-color/);
+    css.should.match(/\.b-color/);
+  });
 });

--- a/test/fixtures/dynamic/a.styl
+++ b/test/fixtures/dynamic/a.styl
@@ -1,0 +1,3 @@
+.a-color { 
+  color: #aaa;
+}

--- a/test/fixtures/dynamic/b.styl
+++ b/test/fixtures/dynamic/b.styl
@@ -1,0 +1,3 @@
+.b-color {
+  color: #bbb;
+}

--- a/test/fixtures/dynamic/index.styl
+++ b/test/fixtures/dynamic/index.styl
@@ -1,0 +1,3 @@
+$foo = "b";
+
+@require "./" + $foo;

--- a/test/import-cache.test.js
+++ b/test/import-cache.test.js
@@ -1,0 +1,33 @@
+var should = require("should");
+var ImportCache = require("../lib/import-cache");
+
+describe("ImportCache", function() {
+  it("should be able to cache imports", function() {
+    var importCache = new ImportCache({ resolve: function() {} });
+    should.not.exist(importCache.lookupImport('x', 'y'));
+    importCache.cacheImport('x', 'y', 'foo');
+    importCache.lookupImport('x', 'y').should.eql('foo');
+    should.not.exist(importCache.lookupImport('x', 'z'));
+    importCache.cacheImport('x', 'z', 'bar');
+    importCache.lookupImport('x', 'y').should.eql('foo');
+    importCache.lookupImport('x', 'z').should.eql('bar');
+  });
+
+  it("should resolve stylus imports", function() {
+    function resolve(context, request, callback) {
+      if (context === 'x' && request === 'y.styl') {
+        callback(null, 'foo');
+      } else if (context === 'x' && request === 'z/index.styl') {
+        callback(null, 'bar');
+      } else {
+        callback(new Error('could not resolve'));
+      }
+    }
+    var importCache = new ImportCache({ resolve: resolve });
+    return Promise.all([
+      importCache.resolveStylusImport('a', 'b').should.be.rejected(),
+      importCache.resolveStylusImport('x', 'y').should.be.fulfilledWith('foo'),
+      importCache.resolveStylusImport('x', 'z').should.be.fulfilledWith('bar')
+    ]);
+  });
+});

--- a/test/import-cache.test.js
+++ b/test/import-cache.test.js
@@ -4,30 +4,30 @@ var ImportCache = require("../lib/import-cache");
 describe("ImportCache", function() {
   it("should be able to cache imports", function() {
     var importCache = new ImportCache({ resolve: function() {} });
-    should.not.exist(importCache.lookupImport('x', 'y'));
-    importCache.cacheImport('x', 'y', 'foo');
-    importCache.lookupImport('x', 'y').should.eql('foo');
-    should.not.exist(importCache.lookupImport('x', 'z'));
-    importCache.cacheImport('x', 'z', 'bar');
-    importCache.lookupImport('x', 'y').should.eql('foo');
-    importCache.lookupImport('x', 'z').should.eql('bar');
+    should.not.exist(importCache.lookupImport("x", "y"));
+    importCache.cacheImport("x", "y", "foo");
+    importCache.lookupImport("x", "y").should.eql("foo");
+    should.not.exist(importCache.lookupImport("x", "z"));
+    importCache.cacheImport("x", "z", "bar");
+    importCache.lookupImport("x", "y").should.eql("foo");
+    importCache.lookupImport("x", "z").should.eql("bar");
   });
 
   it("should resolve stylus imports", function() {
     function resolve(context, request, callback) {
-      if (context === 'x' && request === 'y.styl') {
-        callback(null, 'foo');
-      } else if (context === 'x' && request === 'z/index.styl') {
-        callback(null, 'bar');
+      if (context === "x" && request === "y.styl") {
+        callback(null, "foo");
+      } else if (context === "x" && request === "z/index.styl") {
+        callback(null, "bar");
       } else {
-        callback(new Error('could not resolve'));
+        callback(new Error("could not resolve"));
       }
     }
     var importCache = new ImportCache({ resolve: resolve });
     return Promise.all([
-      importCache.resolveStylusImport('a', 'b').should.be.rejected(),
-      importCache.resolveStylusImport('x', 'y').should.be.fulfilledWith('foo'),
-      importCache.resolveStylusImport('x', 'z').should.be.fulfilledWith('bar')
+      importCache.resolveStylusImport("a", "b").should.be.rejected(),
+      importCache.resolveStylusImport("x", "y").should.be.fulfilledWith("foo"),
+      importCache.resolveStylusImport("x", "z").should.be.fulfilledWith("bar")
     ]);
   });
 });


### PR DESCRIPTION
This PR includes some cleanup, but is mostly for introducing a new way to resolve imports faster.

Cleanup:
- Depending on a `stylus` range with `>=` was insanely unsafe, especially since we muck with some internals. We could require an exact version, but went with `^` for now.
- Move all import resolving & caching logic to `ImportCache`, similar to stylus-loader's separate `PathCache` class.
- Clean some lint, add `check` script.

The perf improvement:
- Instead of resolving each import individually when there's an `UnresolvedImport` error and trying again, keep an eye on any static (meaning: not a dynamic expression, no variables, etc.) `Import` nodes we see in the AST as we're evaluating. Add any such imports we see to a queue. When we finally encounter an unresolved import, resolve the entire queue before retrying (instead of just the single unresolved import we encountered).
- This somewhat resembles the static import analysis done by stylus-loader's `listImports` method (which we ditched), but we don't attempt to statically analyze the entire import tree and resolve it ahead of time (which won't work with dynamic imports). We just happen to be keeping track of any static imports we see in each file as we process it, because we know we'll need to resolve them eventually.

**Summary**
- Before: resolve every import as it's actually attempted, then retry.
- After: resolve every import as it's actually attempted, along with any other static imports we happen to know about in the AST, then retry.

The `R-Discovery/home` app build time when from ~14.5 minutes to ~2.5 minutes. Still slower than before our new import resolution method, but not nearly as bad.

/cc @ryanisinallofus @ryan-roemer 
