### PR TITLE
Visit static imports for better perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ resolve as if they were full absolute paths. That means you'd get all of
 branches or with `$variable` interpolation in the path. `stylus-loader` does not
 support these and sometimes emits confusing error messages as a result.
 
-This is possible because there is no static analysis step to find imports like
-there is in `stylus-loader`. The Stylus renderer is invoked, and when any
-"missing" imports are encountered, they are resolved before trying again from
-the beginning. This sounds like it would be slow, but in practice it's not
-noticeable for the applications we've tested, and has the benefit of
+This is possible because the static import analysis step in
+`stylus-relative-loader` exists purely to increase performance, and is not a
+requirement for import resolution like it is in `stylus-loader`. Our general
+strategy is to invoke the Stylus renderer, and when any "unresolved" imports are
+encountered, we stop rendering, resolved any queued up imports, then try
+rendering again from the beginning. This makes `stylus-relative-loader` slower
+than `stylus-loader` if you have many dynamic imports, but has the benefit of
 correctness. Be careful if you have Stylus plugins with expensive side-effects.
 
 ### Status of this fork

--- a/bench/index.js
+++ b/bench/index.js
@@ -7,8 +7,8 @@ global.fs = require('fs');
 
 var Benchmark = require('benchmark');
 var webpack = require('webpack');
-var MemoryFileSystem = require('webpack-dev-server/node_modules/webpack-dev-middleware/node_modules/memory-fs');
-var when = require('when');
+var MemoryFileSystem = require('memory-fs');
+var Promise = require('bluebird');
 
 var importWebpackConfig = require('./fixtures/imports/webpack.config');
 
@@ -16,7 +16,7 @@ function resolveOnComplete(fn) {
   return function() {
     var _this = this;
     var args = arguments;
-    return when.promise(function(resolve) {
+    return new Promise(function(resolve) {
       var result = fn.apply(_this, args);
       result.on('complete', function() {
         resolve();
@@ -25,7 +25,7 @@ function resolveOnComplete(fn) {
   };
 }
 
-when
+Promise
   .resolve()
   .then(resolveOnComplete(function() {
     var suite = new Benchmark.Suite;

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -1,8 +1,6 @@
 'use strict';
-var dirname = require('path').dirname;
 var Evaluator = require('stylus/lib/visitor/evaluator');
 var utils = require('stylus/lib/utils');
-var loaderUtils = require('loader-utils');
 var UnresolvedImport = require('./unresolved-import');
 
 var _find = utils.find;
@@ -19,14 +17,16 @@ var _lookupIndex = utils.lookupIndex;
 // exception purely for flow-control, telling our outer render "loop" to
 // use webpack's `resolve` on the requested file and try again.
 function lookupIndex(options, name, paths, filename) {
-  // `utils.lookupIndex` is recursive, so temporarily replace it with the version
-  // that it expects, so our fallback doesn't kick in on the first recursive call.
+  // `utils.lookupIndex` uses both `find` and `lookupIndex` (recursively), so
+  // temporarily replace them with the originals.
+  utils.find = _find;
   utils.lookupIndex = _lookupIndex;
   var found = _lookupIndex.call(utils, name, paths, filename);
+  utils.find = find;
   utils.lookupIndex = lookupIndex;
-  if (!found) {
+  if (!found && name.indexOf('~') === 0) {
     var context = paths[paths.length - 1];
-    var request = loaderUtils.urlToRequest(name, options.root);
+    var request = options.importCache.nameToRequest(name);
     var result = options.importCache.lookupImport(context, request);
     if (result) {
       found = [result];
@@ -47,53 +47,18 @@ function CachedPathEvaluator() {
 CachedPathEvaluator.prototype = Object.create(Evaluator.prototype);
 CachedPathEvaluator.prototype.constructor = CachedPathEvaluator;
 
-/**
- * Given an array of `nodes`, find any Import nodes that have a static webpack
- * path - that is, begins with `~` and is not an expression with things like
- * variable interpolation, etc. Add them to the import queue to be resolved
- * the next time we escape the render in progress.
- * @param {Array} nodes - An array of Stylus AST nodes.
- * @return {undefined}
- */
-CachedPathEvaluator.prototype._enqueueImportNodes = function(nodes) {
-  nodes.forEach(function(node) {
-    if (node.constructor.name === 'Import' &&
-        node.path.nodes.length === 1 &&
-        node.path.first.constructor.name === 'String') {
-      var pathNode = node.path.first;
-      if (pathNode.val.indexOf('~') === 0) {
-        var context = dirname(pathNode.filename);
-        var request = loaderUtils.urlToRequest(pathNode.val, this.options.root);
-        this.options.importCache.enqueueImport(context, request);
-      }
-    }
-  }, this);
-};
-
-CachedPathEvaluator.prototype.visitRoot = function(block) {
-  /* eslint-disable eqeqeq */
-  // This is how Stylus itself checks (==), so duplicate that here.
-  if (block == this.root) {
-    this._enqueueImportNodes(block.nodes);
-  }
-  return Evaluator.prototype.visitRoot.apply(this, arguments);
-};
-
-CachedPathEvaluator.prototype.visitBlock = function(block) {
-  this._enqueueImportNodes(block.nodes);
-  return Evaluator.prototype.visitBlock.apply(this, arguments);
-};
-
 CachedPathEvaluator.prototype.visitImport = function() {
   // Patch up `utils.find` and `utils.lookupIndex` with our custom hook.
+  var __find = utils.find;
+  var __lookupIndex = utils.lookupIndex;
   utils.find = find.bind(utils, this.options);
   utils.lookupIndex = lookupIndex.bind(utils, this.options);
   try {
     return Evaluator.prototype.visitImport.apply(this, arguments);
   } finally {
     // Replace originals in case other libraries are doing stuff with `stylus`.
-    utils.find = _find;
-    utils.lookupIndex = _lookupIndex;
+    utils.find = __find;
+    utils.lookupIndex = __lookupIndex;
   }
 };
 

--- a/lib/import-cache.js
+++ b/lib/import-cache.js
@@ -1,19 +1,19 @@
 'use strict';
 var path = require('path');
-var whenNodefn = require('when/node/function');
+var Promise = require('bluebird');
 var loaderUtils = require('loader-utils');
 var UnresolvedImport = require('./unresolved-import');
 var visitImports = require('./import-visitor');
 
 function ImportCache(loaderContext, options) {
   // webpack's `resolve`, promisified.
-  this.resolve = whenNodefn.lift(loaderContext.resolve).bind(loaderContext);
+  this.resolve = Promise.promisify(loaderContext.resolve, { context: loaderContext });
   this.resolveCache = {};
   this.resolveQueue = [];
   this.dependencies = {};
   this.visitQueue = [];
   this.visitCache = {};
-  this.visitSourceCache = {};
+  this.visitImports = visitImports;
   this.options = options;
 }
 
@@ -37,6 +37,9 @@ ImportCache.prototype.cacheImport = function(context, request, result) {
  * require multiple attempts.
  * @param {String} context - Directory of the file in which the import is found.
  * @param {String} request - Path the file is attempting to import.
+ * @param {Boolean} visitOnly - Whether we're only trying to resolve this file
+ *                              in order to visit imports, in which case we don't
+ *                              care if resolution fails.
  * @return {Promise} Promise that will evaluate to the resolved import path,
  *                   or throw if it can't be resolved.
  */
@@ -118,21 +121,22 @@ ImportCache.prototype.enqueueImport = function(context, request, visitOnly) {
 
 ImportCache.prototype.flushVisitQueue = function() {
   if (this.visitQueue.length) {
-    var self = this;
-    var next = this.visitQueue.shift();
-    var filename = next[0];
-    var source = next[1];
+    // Flush the queue in parallel since we have a worker farm.
+    var visit = this.visitQueue.shift();
+    var filename = visit[0];
+    var source = visit[1];
     if (this.visitCache[filename]) {
       return Promise.resolve();
     }
-    var sourceCache = this.visitSourceCache;
-    return visitImports(filename, source, sourceCache).then(function(importPaths) {
-      self.visitCache[filename] = true;
+    this.visitCache[filename] = true;
+    var self = this;
+    return this.visitImports(filename, source).then(function(importPaths) {
       importPaths.forEach(function(importPath) {
         var context = importPath[0];
-        var request = self.nameToRequest(importPath[1]);
-        self.enqueueImport(context, request, true);
-      });
+        var request = this.nameToRequest(importPath[1]);
+        this.enqueueImport(context, request, true);
+      }, self);
+      return self.flushVisitQueue();
     });
   } else {
     return Promise.resolve();
@@ -141,22 +145,25 @@ ImportCache.prototype.flushVisitQueue = function() {
 
 ImportCache.prototype.flushImportQueue = function() {
   if (this.resolveQueue.length) {
-    var self = this;
+    // Flush the queue in series. We could use `Promise.all` to resolve
+    // everything in parallel, but it wasn't found to be any faster.
     var next = this.resolveQueue.shift();
     var context = next[0];
     var request = next[1];
     var visitOnly = next[2];
-    // We could use `Promise.all` and process the whole queue with as much
-    // parallelism as webpack's `resolve` will allow, but that must not be much
-    // because it didn't end up saving any time when tested.
-    return this.resolveStylusImport(context, request, visitOnly).then(function() {
-      return self.flushVisitQueue();
-    }).then(function() {
-      return self.flushImportQueue();
-    });
+    return this.resolveStylusImport(context, request, visitOnly).then(this.flushQueues.bind(this));
   } else {
     return Promise.resolve();
   }
+};
+
+ImportCache.prototype.flushQueues = function() {
+  // Flush both queues in parallel, but make sure `flushImportQueue` is run
+  // again at the end.
+  return Promise.all([
+    this.flushVisitQueue(),
+    this.flushImportQueue()
+  ]).then(this.flushImportQueue.bind(this));
 };
 
 ImportCache.prototype.addDependencies = function(filenames) {
@@ -180,7 +187,7 @@ ImportCache.prototype.handleUnresolvedImport = function(err) {
     var context = err.importContext;
     var request = err.importRequest;
     this.enqueueImport(context, request);
-    return this.flushImportQueue();
+    return this.flushQueues();
   } else {
     throw err;
   }

--- a/lib/import-cache.js
+++ b/lib/import-cache.js
@@ -1,15 +1,25 @@
 'use strict';
 var path = require('path');
 var whenNodefn = require('when/node/function');
+var loaderUtils = require('loader-utils');
 var UnresolvedImport = require('./unresolved-import');
+var visitImports = require('./import-visitor');
 
-function ImportCache(loaderContext) {
+function ImportCache(loaderContext, options) {
   // webpack's `resolve`, promisified.
   this.resolve = whenNodefn.lift(loaderContext.resolve).bind(loaderContext);
   this.resolveCache = {};
   this.resolveQueue = [];
   this.dependencies = {};
+  this.visitQueue = [];
+  this.visitCache = {};
+  this.visitSourceCache = {};
+  this.options = options;
 }
+
+ImportCache.prototype.nameToRequest = function(name) {
+  return loaderUtils.urlToRequest(name, this.options.root);
+};
 
 ImportCache.prototype.lookupImport = function(context, request) {
   var contextImports = this.resolveCache[context] || {};
@@ -30,7 +40,7 @@ ImportCache.prototype.cacheImport = function(context, request, result) {
  * @return {Promise} Promise that will evaluate to the resolved import path,
  *                   or throw if it can't be resolved.
  */
-ImportCache.prototype.resolveStylusImport = function(context, request) {
+ImportCache.prototype.resolveStylusImport = function(context, request, visitOnly) {
   var cached = this.lookupImport(context, request);
   if (cached) {
     return Promise.resolve(cached);
@@ -59,14 +69,38 @@ ImportCache.prototype.resolveStylusImport = function(context, request) {
     });
   }
 
-  return resolveRequest.then(function(result) {
-    self.cacheImport(context, request, result);
-    self.cacheImport(context, finalRequest, result);
+  return resolveRequest.catch(function(err) {
+    // This import is probably relying on Stylus' import logic, not webpack's,
+    // which we *could* duplicate here, although it would be difficult to
+    // duplicate the same stack of `paths`. Anyway, if we're only trying to
+    // resolve this file for the purposes of visiting imports (to speed things
+    // up), then we can ignore it.
+    if (!visitOnly) {
+      throw err;
+    }
+  }).then(function(result) {
+    if (result) {
+      self.enqueueVisit(result);
+      self.cacheImport(context, request, result);
+      self.cacheImport(context, finalRequest, result);
+    }
     return result;
   });
 };
 
-ImportCache.prototype.enqueueImport = function(context, request) {
+ImportCache.prototype.enqueueVisit = function(filename, source) {
+  // Don't visit non-Stylus files or those already visited.
+  if (/\.styl$/i.test(filename) && !this.visitCache[filename]) {
+    var existing = this.visitQueue.filter(function(visit) {
+      return visit[0] === filename;
+    });
+    if (!existing.length) {
+      this.visitQueue.push([filename, source]);
+    }
+  }
+};
+
+ImportCache.prototype.enqueueImport = function(context, request, visitOnly) {
   // Make sure it's not already resolved.
   if (!this.lookupImport(context, request)) {
     // Check that it doesn't already exist in the queue, to prevent duplicates.
@@ -77,8 +111,31 @@ ImportCache.prototype.enqueueImport = function(context, request) {
       return unresolvedImport[0] === context && unresolvedImport[1] === request;
     });
     if (!existing.length) {
-      this.resolveQueue.push([context, request]);
+      this.resolveQueue.push([context, request, visitOnly]);
     }
+  }
+};
+
+ImportCache.prototype.flushVisitQueue = function() {
+  if (this.visitQueue.length) {
+    var self = this;
+    var next = this.visitQueue.shift();
+    var filename = next[0];
+    var source = next[1];
+    if (this.visitCache[filename]) {
+      return Promise.resolve();
+    }
+    var sourceCache = this.visitSourceCache;
+    return visitImports(filename, source, sourceCache).then(function(importPaths) {
+      self.visitCache[filename] = true;
+      importPaths.forEach(function(importPath) {
+        var context = importPath[0];
+        var request = self.nameToRequest(importPath[1]);
+        self.enqueueImport(context, request, true);
+      });
+    });
+  } else {
+    return Promise.resolve();
   }
 };
 
@@ -88,10 +145,13 @@ ImportCache.prototype.flushImportQueue = function() {
     var next = this.resolveQueue.shift();
     var context = next[0];
     var request = next[1];
+    var visitOnly = next[2];
     // We could use `Promise.all` and process the whole queue with as much
     // parallelism as webpack's `resolve` will allow, but that must not be much
     // because it didn't end up saving any time when tested.
-    return this.resolveStylusImport(context, request).then(function() {
+    return this.resolveStylusImport(context, request, visitOnly).then(function() {
+      return self.flushVisitQueue();
+    }).then(function() {
       return self.flushImportQueue();
     });
   } else {
@@ -106,6 +166,7 @@ ImportCache.prototype.addDependencies = function(filenames) {
   // efficient. So collect all dependencies until the end, then add them in one
   // batch.
   filenames.forEach(function(filename) {
+    this.enqueueVisit(filename);
     this.dependencies[filename] = true;
   }, this);
 };
@@ -114,27 +175,15 @@ ImportCache.prototype.getDependencies = function() {
   return Object.keys(this.dependencies);
 };
 
-/**
- * Return a function suitable for passing to a Promise's `catch`, that
- * catches any `UnresolvedImport` errors and attempts to resolve them (along
- * with any other queued imports) before trying again via `done`.
- * @param {Function} done - A retry function that returns the final value or
- *                          a Promise.
- * @return {Function} A function for use with a Promise's `catch`.
- */
-ImportCache.prototype.createUnresolvedImportHandler = function(done) {
-  var self = this;
-  return function(err) {
-    if (!(err instanceof UnresolvedImport)) {
-      throw err;
-    }
-
+ImportCache.prototype.handleUnresolvedImport = function(err) {
+  if (err instanceof UnresolvedImport) {
     var context = err.importContext;
     var request = err.importRequest;
-
-    self.enqueueImport(context, request);
-    return self.flushImportQueue().then(done);
-  };
+    this.enqueueImport(context, request);
+    return this.flushImportQueue();
+  } else {
+    throw err;
+  }
 };
 
 module.exports = ImportCache;

--- a/lib/import-visitor.js
+++ b/lib/import-visitor.js
@@ -1,82 +1,40 @@
 'use strict';
 var fs = require('fs');
 var dirname = require('path').dirname;
-var whenNodefn = require('when/node/function');
-var Parser = require('stylus/lib/parser');
-var Visitor = require('stylus/lib/visitor');
-var nodes = require('stylus/lib/nodes');
+var Promise = require('bluebird');
 
-// ImportVisitor is a simple stylus ast visitor that navigates the graph
-// building a list of imports in it.
-function ImportVisitor(root) {
-  Visitor.call(this, root);
-  this.importedPaths = [];
-}
+// Find lines that look like:
+// @require "...";
+// @import '...';
+// etc.
+var regex = /^\s*@(?:import|require) +['"]([^'"$]+)['"]/m;
 
-ImportVisitor.prototype = Object.create(Visitor.prototype);
-ImportVisitor.prototype.constructor = ImportVisitor;
-
-ImportVisitor.prototype.visitImport = function(node) {
-  // Only find static imports, not dynamic expressions.
-  if (node.path.nodes.length === 1 && node.path.first.constructor.name === 'String') {
-    var name = node.path.first.val;
-    this.importedPaths.push(name);
-  }
-  return node;
-};
-
-ImportVisitor.prototype.visitRoot = function(block) {
-  for (var i = 0; i < block.nodes.length; ++i) {
-    this.visit(block.nodes[i]);
-  }
-  return block;
-};
-
-ImportVisitor.prototype.visitExpression = function(expr) {
-  for (var i = 0; i < expr.nodes.length; ++i) {
-    this.visit(expr.nodes[i]);
-  }
-  return expr;
-};
-
-ImportVisitor.prototype.visitBlock = ImportVisitor.prototype.visitRoot;
-
-// Return a Promise resolving to a list of paths that given file imports.
-function visitImports(filename, knownSource, sourceCache) {
-  // If we already have the source, don't bother reading the file.
+/**
+ * We could use the real Stylus parser and visit each node in the AST to find
+ * imports. But given that we only need to discover import-like things for
+ * performance purposes, and not to render successfully, it's faster just to
+ * scan the source string for lines that look like imports. Even if we don't
+ * find all imports, or find commented-out imports, it won't affect the final
+ * rendered output.
+ * @param {String} filename - The filename of the file being processed.
+ * @param {String|null} knownSource - The contents of the file, if already
+ *                                    known; this was save us from having to
+ *                                    read the file.
+ * @returns {Promise} Promise resolving to an array of [context, name] pairs.
+ */
+function visitImports(filename, knownSource) {
+  // Promisify here instead of outer scope because in tests, `fs` will be
+  // replaced with `empty` module.
+  var readFile = Promise.promisify(fs.readFile);
   var promise = knownSource == null ?
-    whenNodefn.call(fs.readFile, filename, 'utf8') :
-    Promise.resolve(knownSource);
+    readFile(filename, 'utf8') : Promise.resolve(knownSource);
 
   return promise.then(function(source) {
-    // If `source` is in `sourceCache`, don't bother parsing and visiting the
-    // AST - we already know what strings are imported. However, they might
-    // have been imported from a file with in a different location, meaningful
-    // `context` will be different - so just get the import strings and then
-    // return them with this file's `context` at the end.
-    var importedPaths = sourceCache[source];
-    if (!importedPaths) {
-      var _filename = nodes.filename;
-      nodes.filename = filename;
-      // Current idea here is to silence errors and let them rise in stylus's
-      // renderer which has more handling so that the error message is more
-      // meaningful and easy to understand.
-      var parser = new Parser(source, { cache: false });
-
-      try {
-        var ast = parser.parse();
-      } catch (e) {
-        return [];
-      } finally {
-        nodes.filename = _filename;
-      }
-
-      var importVisitor = new ImportVisitor(ast);
-      importVisitor.visit(ast);
-      importedPaths = importVisitor.importedPaths;
-      sourceCache[source] = importedPaths;
+    var parts = source.split(regex);
+    var importedPaths = [];
+    for (var i = 1; i < parts.length; i += 2) {
+      importedPaths.push(parts[i]);
     }
-
     var context = dirname(filename);
     return importedPaths.map(function(name) {
       return [context, name];

--- a/lib/import-visitor.js
+++ b/lib/import-visitor.js
@@ -1,0 +1,87 @@
+'use strict';
+var fs = require('fs');
+var dirname = require('path').dirname;
+var whenNodefn = require('when/node/function');
+var Parser = require('stylus/lib/parser');
+var Visitor = require('stylus/lib/visitor');
+var nodes = require('stylus/lib/nodes');
+
+// ImportVisitor is a simple stylus ast visitor that navigates the graph
+// building a list of imports in it.
+function ImportVisitor(root) {
+  Visitor.call(this, root);
+  this.importedPaths = [];
+}
+
+ImportVisitor.prototype = Object.create(Visitor.prototype);
+ImportVisitor.prototype.constructor = ImportVisitor;
+
+ImportVisitor.prototype.visitImport = function(node) {
+  // Only find static imports, not dynamic expressions.
+  if (node.path.nodes.length === 1 && node.path.first.constructor.name === 'String') {
+    var name = node.path.first.val;
+    this.importedPaths.push(name);
+  }
+  return node;
+};
+
+ImportVisitor.prototype.visitRoot = function(block) {
+  for (var i = 0; i < block.nodes.length; ++i) {
+    this.visit(block.nodes[i]);
+  }
+  return block;
+};
+
+ImportVisitor.prototype.visitExpression = function(expr) {
+  for (var i = 0; i < expr.nodes.length; ++i) {
+    this.visit(expr.nodes[i]);
+  }
+  return expr;
+};
+
+ImportVisitor.prototype.visitBlock = ImportVisitor.prototype.visitRoot;
+
+// Return a Promise resolving to a list of paths that given file imports.
+function visitImports(filename, knownSource, sourceCache) {
+  // If we already have the source, don't bother reading the file.
+  var promise = knownSource == null ?
+    whenNodefn.call(fs.readFile, filename, 'utf8') :
+    Promise.resolve(knownSource);
+
+  return promise.then(function(source) {
+    // If `source` is in `sourceCache`, don't bother parsing and visiting the
+    // AST - we already know what strings are imported. However, they might
+    // have been imported from a file with in a different location, meaningful
+    // `context` will be different - so just get the import strings and then
+    // return them with this file's `context` at the end.
+    var importedPaths = sourceCache[source];
+    if (!importedPaths) {
+      var _filename = nodes.filename;
+      nodes.filename = filename;
+      // Current idea here is to silence errors and let them rise in stylus's
+      // renderer which has more handling so that the error message is more
+      // meaningful and easy to understand.
+      var parser = new Parser(source, { cache: false });
+
+      try {
+        var ast = parser.parse();
+      } catch (e) {
+        return [];
+      } finally {
+        nodes.filename = _filename;
+      }
+
+      var importVisitor = new ImportVisitor(ast);
+      importVisitor.visit(ast);
+      importedPaths = importVisitor.importedPaths;
+      sourceCache[source] = importedPaths;
+    }
+
+    var context = dirname(filename);
+    return importedPaths.map(function(name) {
+      return [context, name];
+    });
+  });
+}
+
+module.exports = visitImports;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylus-relative-loader",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Stylus loader for webpack, with fixed imports",
   "main": "index.js",
   "files": [
@@ -26,25 +26,25 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.9",
-    "when": "~3.6.x"
+    "when": "^3.7.7"
   },
   "devDependencies": {
-    "benchmark": "^1.0.0",
-    "css-loader": "^0.14.0",
+    "benchmark": "^2.1.1",
+    "css-loader": "^0.23.1",
     "eslint": "^1.10.3",
     "eslint-config-defaults": "^9.0.0",
     "eslint-plugin-filenames": "^0.2.0",
-    "mocha": "~2.1.0",
-    "mocha-loader": "~0.7.1",
-    "nib": "^1.0.4",
-    "node-libs-browser": "^0.5.2",
-    "raw-loader": "~0.5.1",
-    "should": "^9.0.2",
-    "style-loader": "^0.12.2",
+    "mocha": "^2.5.3",
+    "mocha-loader": "^0.7.1",
+    "nib": "^1.1.0",
+    "node-libs-browser": "^1.0.0",
+    "raw-loader": "^0.5.1",
+    "should": "^10.0.0",
+    "style-loader": "^0.13.1",
     "stylus": "^0.54.5",
-    "testem": "^0.8.3",
-    "webpack": "^1.9.8",
-    "webpack-dev-server": "~1.7.0"
+    "testem": "^1.10.1",
+    "webpack": "^1.13.1",
+    "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
     "stylus": "^0.54.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylus-relative-loader",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Stylus loader for webpack, with fixed imports",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/walmartlabs/stylus-relative-loader/issues"
   },
   "dependencies": {
-    "loader-utils": "^0.2.9",
-    "when": "^3.7.7"
+    "bluebird": "^3.4.1",
+    "loader-utils": "^0.2.9"
   },
   "devDependencies": {
     "benchmark": "^2.1.1",
@@ -34,6 +34,7 @@
     "eslint": "^1.10.3",
     "eslint-config-defaults": "^9.0.0",
     "eslint-plugin-filenames": "^0.2.0",
+    "memory-fs": "^0.3.0",
     "mocha": "^2.5.3",
     "mocha-loader": "^0.7.1",
     "nib": "^1.1.0",

--- a/test/import-cache.test.js
+++ b/test/import-cache.test.js
@@ -3,7 +3,7 @@ var ImportCache = require("../lib/import-cache");
 
 describe("ImportCache", function() {
   it("should be able to cache imports", function() {
-    var importCache = new ImportCache({ resolve: function() {} });
+    var importCache = new ImportCache({ resolve: function() {} }, {});
     should.not.exist(importCache.lookupImport("x", "y"));
     importCache.cacheImport("x", "y", "foo");
     importCache.lookupImport("x", "y").should.eql("foo");
@@ -23,7 +23,7 @@ describe("ImportCache", function() {
         callback(new Error("could not resolve"));
       }
     }
-    var importCache = new ImportCache({ resolve: resolve });
+    var importCache = new ImportCache({ resolve: resolve }, {});
     return Promise.all([
       importCache.resolveStylusImport("a", "b").should.be.rejected(),
       importCache.resolveStylusImport("x", "y").should.be.fulfilledWith("foo"),

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -20,6 +20,9 @@ if (process.env.WEBPACK_VERSION === '2.1.0-beta.7') {
   module.exports = {
     context: __dirname,
     entry: 'mocha-loader!./all.js',
+    node: {
+      fs: "empty"
+    },
     resolve: {
       enforceExtensions: false,
       extensions: [
@@ -44,6 +47,9 @@ if (process.env.WEBPACK_VERSION === '2.1.0-beta.7') {
   module.exports = {
     context: __dirname,
     entry: "mocha-loader!./all.js",
+    node: {
+      fs: "empty"
+    },
     resolve: {
       extensions: ["", ".js", ".css", ".styl"]
     },


### PR DESCRIPTION
This uses a simple regex on each Stylus file in order to discover statically imported files.

Unlike `stylus-loader` which uses a Visitor to crawl the file's AST and attempt to find the entire dependency tree before attempting its single render (which will fail for dynamic imports), this just attempts to find as much as reasonably possible before/between each render attempt.

Even if the entire dependency tree can't be reached (due to dynamic imports or not being able to replicate weirdo Stylus resolution rules), it's still better to have as much resolved beforehand as possible.

All the resolution done by `visitImports` is purely for perf gains and doesn't affect _how_ things are actually resolved at render time. If its regex turns out to be bad, or it finds commented-out imports, or whatever, it doesn't really matter – it's only expanding the _potential_ dependency tree to increase resolution performance.

Depending on the app, this greatly improves build times. On the low side, 8 min → 5 min, on the high side, 39 min → 2 min.

Also bumps deps.

Fixes #7.

Also tried:
- Having a process pool of workers whose job it is to parse each Stylus file and crawl the AST for imports, then send results back to the main process. This wasn't any faster than just having one process use a simple regex.

/cc @ryanisinallofus @ananavati
