### PR TITLE
Switch from bluebird to es6-promise

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -8,7 +8,7 @@ global.fs = require('fs');
 var Benchmark = require('benchmark');
 var webpack = require('webpack');
 var MemoryFileSystem = require('memory-fs');
-var Promise = require('bluebird');
+var Promise = require('es6-promise').Promise;
 
 var importWebpackConfig = require('./fixtures/imports/webpack.config');
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var loaderUtils = require('loader-utils');
 var stylus = require('stylus');
 var path = require('path');
-var Promise = require('bluebird');
+var Promise = require('es6-promise').Promise;
 
 var CachedPathEvaluator = require('./lib/evaluator');
 var ImportCache = require('./lib/import-cache');
@@ -90,7 +90,13 @@ module.exports = function(source) {
   });
 
   // `styl.render`, promisified.
-  var renderStylus = Promise.promisify(styl.render, { context: styl });
+  var renderStylus = function() {
+    return new Promise(function(resolve, reject) {
+      styl.render(function(err, css) {
+        return err ? reject(err) : resolve(css);
+      });
+    });
+  };
 
   function tryRender() {
     return renderStylus().then(function(css) {

--- a/lib/import-cache.js
+++ b/lib/import-cache.js
@@ -1,13 +1,19 @@
 'use strict';
 var path = require('path');
-var Promise = require('bluebird');
+var Promise = require('es6-promise').Promise;
 var loaderUtils = require('loader-utils');
 var UnresolvedImport = require('./unresolved-import');
 var visitImports = require('./import-visitor');
 
 function ImportCache(loaderContext, options) {
   // webpack's `resolve`, promisified.
-  this.resolve = Promise.promisify(loaderContext.resolve, { context: loaderContext });
+  this.resolve = function(context, request) {
+    return new Promise(function(resolve, reject) {
+      loaderContext.resolve(context, request, function(err, result) {
+        return err ? reject(err) : resolve(result);
+      });
+    });
+  };
   this.resolveCache = {};
   this.resolveQueue = [];
   this.dependencies = {};

--- a/lib/import-visitor.js
+++ b/lib/import-visitor.js
@@ -1,7 +1,7 @@
 'use strict';
 var fs = require('fs');
 var dirname = require('path').dirname;
-var Promise = require('bluebird');
+var Promise = require('es6-promise').Promise;
 
 // Find lines that look like:
 // @require "...";
@@ -25,7 +25,13 @@ var regex = /^\s*@(?:import|require) +['"]([^'"$]+)['"]/m;
 function visitImports(filename, knownSource) {
   // Promisify here instead of outer scope because in tests, `fs` will be
   // replaced with `empty` module.
-  var readFile = Promise.promisify(fs.readFile);
+  var readFile = function(file, options) {
+    return new Promise(function(resolve, reject) {
+      fs.readFile(file, options, function(err, data) {
+        return err ? reject(err) : resolve(data);
+      });
+    });
+  };
   var promise = knownSource == null ?
     readFile(filename, 'utf8') : Promise.resolve(knownSource);
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/walmartlabs/stylus-relative-loader/issues"
   },
   "dependencies": {
-    "bluebird": "^3.4.1",
+    "es6-promise": "^3.2.1",
     "loader-utils": "^0.2.9"
   },
   "devDependencies": {


### PR DESCRIPTION
This attempts to fix #12 by switching the Promise library from `bluebird` to `es6-promise`.
