### PR TITLE
Work around broken query parsing in merged configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var loaderUtils = require('loader-utils');
 var stylus = require('stylus');
 var path = require('path');
 var Promise = require('es6-promise').Promise;
+var util = require('util');
 
 var CachedPathEvaluator = require('./lib/evaluator');
 var ImportCache = require('./lib/import-cache');
@@ -21,9 +22,19 @@ module.exports = function(source) {
   }
   var done = this.async();
   var options = loaderUtils.parseQuery(this.query);
+
+  debug('Loader options: %s', util.inspect(options));
+
   options.dest = options.dest || '';
   options.filename = options.filename || this.resourcePath;
   options.Evaluator = CachedPathEvaluator;
+  options.precacheImportVariables = (options.precacheImportVariables || []).map(
+    function(importVariables) {
+      return typeof importVariables === 'string'
+        ? loaderUtils.parseQuery('?' + importVariables)
+        : importVariables;
+    }
+  );
 
   // Attach `importCache` to `options` so that the `Evaluator` can access it.
   var importCache = options.importCache = new ImportCache(this, options);


### PR DESCRIPTION
This works around a bug somewhere in webpack, another loader in the chain, or our config merging somehow.

In the webpack@1 version of `extract-text-webpack-plugin`, the loader chain must be a string, like so: `css?foo!stylus?bar`. It can't be a list of objects like so:

``` js
[{ loader: 'css', query: { ... } }, loader: 'stylus', query: { ... } }]
```

That means query options need to be serialized. For complex nested options, you're supposed to be able to do this, [as demonstrated by @sokra](https://github.com/webpack/webpack/issues/482#issuecomment-56161239):

``` js
"stylus?{ foo: 1, bar: 'two' }"
// or more conveniently:
"stylus?" + JSON.stringify(options)
```

This works in some versions of our archetype's webpack config. In others, we get this error:

```
ERROR in ./~/css-loader?-autoprefixer!./~/stylus-relative-loader?{"precacheImportVariables":[object Object]}!./client/styles/base.styl
Module build failed: SyntaxError: Unexpected 'o' at line 1 column 30 of the JSON5 data. Still to read: "object Object]}"
    at JSON5.parse.error (/Users/brianbeck/Projects/Walmart/product/node_modules/loader-utils/node_modules/json5/lib/json5.js:56:25)
```

Notice how the array gets turned into `[object Object]` – some module somewhere else in the chain is taking our perfectly fine JSON query, parsing it, then doing a terrible job re-serializating it, incorrectly, before it even gets to us.

So this PR introduces extra parsing of the `precacheImportVariables` option, which lets us specify it as a non-JSON query string by doing an extra `parseQuery`. 😠 

/cc @ananavati @jmcriffey
